### PR TITLE
Update font name; Add PAT token as authentication.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -26,8 +26,8 @@ local function show_warning(status, body)
     }):send()
 end
 
-local user_icon = hs.styledtext.new(' ', { font = {name = 'feather', size = 12 }, color = {hex = '#8e8e8e'}})
-local ticket_icon = hs.styledtext.new(' ', { font = {name = 'feather', size = 12 }, color = {hex = '#8e8e8e'}})
+local user_icon = hs.styledtext.new(' ', { font = {name = 'icomoon', size = 12 }, color = {hex = '#8e8e8e'}})
+local ticket_icon = hs.styledtext.new(' ', { font = {name = 'icomoon', size = 12 }, color = {hex = '#8e8e8e'}})
 
 local function styledText(text)
     return hs.styledtext.new(text, {color = {hex = '#8e8e8e'}})
@@ -165,7 +165,11 @@ end
 
 function obj:setup(args)
     self.jira_host = args.jira_host
-    auth_header = 'Basic ' .. hs.base64.encode(string.format('%s:%s', args.login, args.api_token))
+    if args.api_token ~= nil then
+        auth_header = 'Basic ' .. hs.base64.encode(string.format('%s:%s', args.login, args.api_token))
+    else
+        auth_header = 'Bearer ' .. args.pat_token
+    end
     if args.jql ~= nil then obj.jql = args.jql end
 end
 


### PR DESCRIPTION
This pull request includes changes to the `init.lua` file, primarily focusing on the modification of icon fonts and the addition of a new authentication method. The most significant changes are:

Icon Font Modification:
* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L29-R30): The `show_warning(status, body)` function has been updated to use the 'icomoon' font instead of the 'feather' font for both `user_icon` and `ticket_icon`.

Authentication Method Addition:
* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R168-R172): In the `setup(args)` function, a new authentication method has been added. If an API token is provided, it will be used for authentication. Otherwise, a PAT token will be used.